### PR TITLE
removed dependency six.string_types

### DIFF
--- a/imapbackup38.py
+++ b/imapbackup38.py
@@ -55,8 +55,6 @@ import socket
 import re
 import hashlib
 
-from six import string_types
-
 class SkipFolderException(Exception):
     """Indicates aborting processing of current folder, continue with next folder."""
     pass
@@ -123,7 +121,7 @@ def string_from_file(value):
     the '@' with a '\' to treat it as a literal.
     """
 
-    assert isinstance(value, string_types)
+    assert isinstance(value, str)
 
     if not value or value[0] not in ["\\", "@"]:
         return value


### PR DESCRIPTION
Removed dependency on six.string_types and corresponding import

This was a compatibility recommendation between Python 2.x and Python 3.x

imapbackup38.py is not required to be backwards compatible with Python 2.x

was:   
assert isinstance(value,string_types)

is: 
assert isinstance(value,str)

