### PR TITLE
Quote the foldername to prevent issues with spaces #28

### DIFF
--- a/imapbackup.py
+++ b/imapbackup.py
@@ -270,6 +270,7 @@ def scan_file(filename, compress, overwrite, nospinner):
 def scan_folder(server, foldername, nospinner):
     """Gets IDs of messages in the specified folder, returns id:num dict"""
     messages = {}
+    foldername = '"{}"'.format(foldername)
     spinner = Spinner("Folder %s" % foldername, nospinner)
     try:
         typ, data = server.select(foldername, readonly=True)

--- a/imapbackup38.py
+++ b/imapbackup38.py
@@ -259,6 +259,7 @@ def scan_file(filename, overwrite, nospinner, basedir):
 def scan_folder(server, foldername, nospinner):
     """Gets IDs of messages in the specified folder, returns id:num dict"""
     messages = {}
+    foldername = '"{}"'.format(foldername)
     spinner = Spinner("Folder %s" % foldername, nospinner)
     try:
         typ, data = server.select(foldername, readonly=True)


### PR DESCRIPTION
This should resolve the issues with folders, which contain spaces.

I am not sure if this is the best solution. The code works in Python 2 and Python 3 (I tested this separately). Also I do not know if more changes have to be done.

So far it seems to work (small test with a single email in a folder `test (123)`.
<img width="554" alt="Bildschirmfoto 2021-07-18 um 15 36 09" src="https://user-images.githubusercontent.com/827205/126069161-95112359-d960-49f6-9abe-b87fd18f55aa.png">

Besides this, I think we should check if provided parameters have to be quoted (see the details of #28) as this could otherwise lead to arbitrary code execution on the mailserver via IMAP or even directory traversal in `create_folder_structure(names)`.

The changes resolve this error (fetch all folders):

```
Folder INBOX/test (123):
ERROR: EXAMINE command error: BAD [b'Error in IMAP command EXAMINE: Unknown FETCH modifier (0.001 + 0.000 secs).']
```