### PR TITLE
Perform >From quoting as described by RFC 4155 (closes #37)

### DIFF
--- a/imapbackup.py
+++ b/imapbackup.py
@@ -167,6 +167,7 @@ def download_messages(server, filename, messages, config):
     spinner = Spinner("Downloading %s new messages to %s" % (len(messages), filename),
                       config['nospinner'])
     total = biggest = 0
+    from_re = re.compile("\n(>*)From ")
 
     # each new message
     for msg_id in messages.keys():
@@ -190,6 +191,11 @@ def download_messages(server, filename, messages, config):
             # This avoids Thunderbird mistaking a line starting "From  " as the start
             # of a new message. _Might_ also apply to other mail lients - unknown
             text = text.replace("\nFrom ", "\n From ")
+        else:
+            # Perform >From quoting as described by RFC 4155 and the qmail docs.
+            # https://www.rfc-editor.org/rfc/rfc4155.txt
+            # http://qmail.org/qmail-manual-html/man5/mbox.html
+            text = from_re.sub("\n>\\1From ", text)
         mbox.write(text)
         mbox.write('\n\n')
 

--- a/imapbackup38.py
+++ b/imapbackup38.py
@@ -155,6 +155,7 @@ def download_messages(server, filename, messages, overwrite, nospinner, thunderb
     spinner = Spinner("Downloading %s new messages to %s" % (len(messages), filename),
                       nospinner)
     total = biggest = 0
+    from_re = re.compile(b"\n(>*)From ")
 
     # each new message
     for msg_id in messages.keys():
@@ -183,6 +184,11 @@ def download_messages(server, filename, messages, overwrite, nospinner, thunderb
             # This avoids Thunderbird mistaking a line starting "From  " as the start
             # of a new message. _Might_ also apply to other mail lients - unknown
             text_bytes = text_bytes.replace(b"\nFrom ", b"\n From ")
+        else:
+            # Perform >From quoting as described by RFC 4155 and the qmail docs.
+            # https://www.rfc-editor.org/rfc/rfc4155.txt
+            # http://qmail.org/qmail-manual-html/man5/mbox.html
+            text_bytes = from_re.sub(b"\n>\\1From ", text_bytes)
         mbox.write(text_bytes)
         mbox.write(b'\n\n')
 


### PR DESCRIPTION
Fixes #37 

Opening this as a starting point for discussion. The code has been tested with Python 2 and 3 and should work universally. It's a pretty simple fix.

It seems like a bug to me because the resulting mbox files couldn't be read by Python's own mailbox library, so I made it the default behaviour. It could be behind a flag like the thunderbird option, or maybe combined with that one somehow if >From quoting is sufficient for that case as well.

References:
- https://www.rfc-editor.org/rfc/rfc4155.txt
- http://qmail.org/qmail-manual-html/man5/mbox.html

> The program then copies the message, applying >From quoting
> to each line.  >From quoting ensures that the resulting
> lines are not From_ lines:  the program prepends a > to any
> From_ line, >From_ line, >>From_ line, >>>From_ line, etc.
