### PR TITLE
fix a bug that occured for icloud mail

### DIFF
--- a/imapbackup38.py
+++ b/imapbackup38.py
@@ -176,7 +176,7 @@ def download_messages(server, filename, messages, overwrite, nospinner, thunderb
 
         # fetch message
         msg_id_str = str(messages[msg_id])
-        typ, data = server.fetch(msg_id_str, "(BODY[])" if icloud else "(RFC822)")
+        typ, data = server.fetch(msg_id_str, "(BODY.PEEK[])" if icloud else "(RFC822)")
 
 
         assert('OK' == typ)

--- a/imapbackup38.py
+++ b/imapbackup38.py
@@ -179,6 +179,9 @@ def download_messages(server, filename, messages, overwrite, nospinner, thunderb
         typ, data = server.fetch(msg_id_str, "(RFC822)")
         assert('OK' == typ)
         data_bytes = data[0][1]
+        if not isinstance(data_bytes, str):
+            continue
+
         text_bytes = data_bytes.strip().replace(b'\r', b'')
         if thunderbird:
             # This avoids Thunderbird mistaking a line starting "From  " as the start


### PR DESCRIPTION
Fetching messages from iCloud Imap Server did not work because the python imap lib does not work with fetching `(RFC822)` from the icloud server. There are a few discussions about it in the web and the most common solution is to use `(BODY[])` instead `(RFC822)` for icloud servers. 
So I introduced an `--icloud` option flag